### PR TITLE
Use source/external IDs for pdbx_database_status of MA (or any CSM) models

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -84,4 +84,6 @@
 23-Jun-2022 - V0.92 Use ma_target_ref_db_details to populate rcsb_polymer_entity_container_identifiers.reference_sequence_identifiers for MA models
 27-Jun-2022 - V0.93 Update _rcsb_ma_qa_metric_global.ma_qa_metric_global_type to 'pLDDT' for AF models
 29-Jun-2022 - V0.94 Use internal computed-model identifiers for data loading (in same manner as experimental models)
-06-Jul-2022 - V0.95 RO-3357: Fix taxonomy assignment in addPolymerEntityTaxonomy
+06-Jul-2022 - V0.95 RO-3357: Fix taxonomy assignment in addPolymerEntityTaxonomy;
+                    Use source/external IDs for populating pdbx_database_status of MA (or any) computed models;
+                    Only populate rcsb_comp_model_provenance.source_url if it exists in CSM holdings file

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -86,4 +86,5 @@
 29-Jun-2022 - V0.94 Use internal computed-model identifiers for data loading (in same manner as experimental models)
 06-Jul-2022 - V0.95 RO-3357: Fix taxonomy assignment in addPolymerEntityTaxonomy;
                     Use source/external IDs for populating pdbx_database_status of MA (or any) computed models;
-                    Only populate rcsb_comp_model_provenance.source_url if it exists in CSM holdings file
+                    Only populate rcsb_comp_model_provenance.source_url if it exists in CSM holdings file;
+                    Add addtional filters for populating _rcsb_accession_info

--- a/rcsb/utils/dictionary/DictMethodCompModelHelper.py
+++ b/rcsb/utils/dictionary/DictMethodCompModelHelper.py
@@ -13,6 +13,7 @@
 #   17-May-2022   bv Add method 'addStructInfo'
 #   29-Jun-2022  dwp Update method 'buildCompModelProvenance' for populating rcsb_comp_model_provenance using mapping between internal and external IDs
 #    6-Jul-2022   bv RO-3357: Fix taxonomy assignment in addPolymerEntityTaxonomy
+#    6-Jul-2022  dwp Only populate rcsb_comp_model_provenance.source_url if it exists in CSM holdings file (may not exist for all AF fragments)
 ##
 """
 Helper class implements computed model method references in the RCSB dictionary extension.
@@ -336,7 +337,9 @@ class DictMethodCompModelHelper(object):
 
             cObj.setValue(compModelD["sourceId"], "entry_id", 0)
             cObj.setValue(compModelD["sourceDb"], "source_db", 0)
-            cObj.setValue(compModelD["sourceModelUrl"], "source_url", 0)
+            sourceModelUrl = compModelD.get("sourceModelUrl", None)
+            if sourceModelUrl:
+                cObj.setValue(compModelD["sourceModelUrl"], "source_url", 0)
             cObj.setValue(compModelD["sourceModelFileName"], "source_filename", 0)
 
             return True

--- a/rcsb/utils/dictionary/DictMethodEntityHelper.py
+++ b/rcsb/utils/dictionary/DictMethodEntityHelper.py
@@ -77,7 +77,6 @@ class DictMethodEntityHelper(object):
         self.__chemblP = rP.getResource("ChEMBLTargetCofactorProvider instance") if rP else None
         self.__dbP = rP.getResource("DrugBankTargetCofactorProvider instance") if rP else None
         self.__phP = rP.getResource("PharosTargetCofactorProvider instance") if rP else None
-        self.__mcP = rP.getResource("ModelCacheProvider instance") if rP else None
         #
         logger.debug("Dictionary entity method helper init")
 


### PR DESCRIPTION
and only populate rcsb_comp_model_provenance.source_url if it exists in CSM holdings file