### PR TITLE
RO-3413: Add fix for assigning rcsb_entry_info.structure_determination_methodology

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -88,5 +88,6 @@
                     Only populate rcsb_comp_model_provenance.source_url if it exists in CSM holdings file;
                     Add addtional filters for populating _rcsb_accession_info;
                     Only run addDepositedAssembly for computed model files which don't already contain pdbx_struct_assembly
-21-Jul-2022 - V0.96 Update ModelCacheProvider to make providerType "core" and not stashable or buildable
+01-Aug-2022 - V0.96 Update ModelCacheProvider to make providerType "core" and not stashable or buildable
                     Fix logic for assigning reference sequence identifiers for computed models
+                    Override cases where struct.pdbx_structure_determination_methodology is '?' or '.' in mmCIF file

--- a/rcsb/utils/dictionary/DictMethodEntryHelper.py
+++ b/rcsb/utils/dictionary/DictMethodEntryHelper.py
@@ -59,6 +59,7 @@
 #  3-May-2022 dwp Use internal computed-model identifiers for 'entry_id' in containter_identifiers
 # 29-Jun-2022 dwp Use internal computed-model identifiers everywhere (in same manner as experimental models)
 # 06-Jul-2022 dwp Add addtional filters for populating _rcsb_accession_info
+# 01-Aug-2022 dwp Override rcsb_entry_info.structure_determination_methodology if struct.pdbx_structure_determination_methodology is '?' or '.' in the CIF file
 #
 ##
 """
@@ -779,7 +780,7 @@ class DictMethodEntryHelper(object):
                 xObj = dataContainer.getObj("struct")
                 if xObj.hasAttribute("pdbx_structure_determination_methodology"):
                     methodType = xObj.getValue("pdbx_structure_determination_methodology", 0)
-            if not methodType:
+            if not methodType or methodType == "?" or methodType == ".":
                 if dataContainer.exists("exptl"):
                     methodType = "experimental"
                 if dataContainer.exists("ma_data"):

--- a/rcsb/utils/dictionary/DictMethodEntryHelper.py
+++ b/rcsb/utils/dictionary/DictMethodEntryHelper.py
@@ -775,6 +775,7 @@ class DictMethodEntryHelper(object):
             methodCount = 0
             expMethod = None
             methodType = None
+            entryId = None
             #
             if dataContainer.exists("struct"):
                 xObj = dataContainer.getObj("struct")
@@ -798,6 +799,9 @@ class DictMethodEntryHelper(object):
                 mObj = dataContainer.getObj("ma_model_list")
                 methodL = mObj.getAttributeUniqueValueList("model_type")
                 methodCount, expMethod = self.__commonU.filterExperimentalMethod(methodL)
+            #
+            if methodType not in ["experimental", "computational"]:
+                logger.info("Unexpected methodType %r found for entry %r", methodType, entryId)
             #
             cObj.setValue(entryId, "entry_id", 0)
             cObj.setValue(methodCount, "experimental_method_count", 0)

--- a/rcsb/utils/dictionary/DictMethodEntryHelper.py
+++ b/rcsb/utils/dictionary/DictMethodEntryHelper.py
@@ -801,7 +801,7 @@ class DictMethodEntryHelper(object):
                 methodCount, expMethod = self.__commonU.filterExperimentalMethod(methodL)
             #
             if methodType not in ["experimental", "computational"]:
-                logger.info("Unexpected methodType %r found for entry %r", methodType, entryId)
+                logger.error("Unexpected methodType %r found for entry %r", methodType, entryId)
             #
             cObj.setValue(entryId, "entry_id", 0)
             cObj.setValue(methodCount, "experimental_method_count", 0)


### PR DESCRIPTION
Override rcsb_entry_info.structure_determination_methodology if struct.pdbx_structure_determination_methodology is '?' or '.' in the CIF file.

Addresses: https://rcsbpdb.atlassian.net/browse/RO-3413?focusedCommentId=201477

This issue also highlights an need to address this at the data-in process, as mmCIF files should not be allowed to have any value other than "experimental" or "computational" for `struct.pdbx_structure_determination_methodology`.